### PR TITLE
Renaming origin release

### DIFF
--- a/iSpector-installer.nsi
+++ b/iSpector-installer.nsi
@@ -17,7 +17,7 @@ SetCompressor /SOLID /FINAL zlib
 
 ; Don't update these three variables, this should be done with bump-version.py.
 !define MY_VERSION_MAJOR "0"
-!define MY_VERSION_MINOR "8"
+!define MY_VERSION_MINOR "9"
 !define MY_VERSION_MICRO "0"
 
 ; Full application name include major and minor versions, in such way

--- a/iSpectorVersion.py
+++ b/iSpectorVersion.py
@@ -7,7 +7,7 @@ minor version number should be odd for nightly build and even for stable builds.
 name = "iSpector"
 
 iSpector_major = 0
-iSpector_minor = 8
+iSpector_minor = 9
 iSpector_micro = 0
 
 
@@ -39,6 +39,6 @@ if __name__ == "__main__":
     import sys
 
     sys.exit(
-        "Don't run this file, run bump-version.py instead. Without arguments" +
-        " it will print the current version."
+        "Don't run this file, run bump-version.py instead. Without arguments"
+        + " it will print the current version."
     )

--- a/iSpectorVersion.py
+++ b/iSpectorVersion.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python3
-
-'''
+"""
 This file should not be editted by hand. Typically it is modified by using the
 'bump-version.py' script. It reflects the build version of eye spector. The
 minor version number should be odd for nightly build and even for stable builds.
-'''
+"""
 
 name = "iSpector"
 
@@ -12,19 +10,35 @@ iSpector_major = 0
 iSpector_minor = 8
 iSpector_micro = 0
 
+
 def getVersionMajor():
     return iSpector_major
+
 
 def getVersionMinor():
     return iSpector_minor
 
+
 def getVersionMicro():
     return iSpector_micro
 
+
 def getVersion():
-    return name + "-" + str(iSpector_major) + "." +         \
-            str(iSpector_minor) + "." + str(iSpector_micro)
+    return (
+        name
+        + "-"
+        + str(iSpector_major)
+        + "."
+        + str(iSpector_minor)
+        + "."
+        + str(iSpector_micro)
+    )
+
 
 if __name__ == "__main__":
     import sys
-    print("Don't run this file, run bump-version.py instead", file=sys.stderr)
+
+    sys.exit(
+        "Don't run this file, run bump-version.py instead. Without arguments" +
+        " it will print the current version."
+    )


### PR DESCRIPTION
This release reflects that we are now part of ils-labs instead of UiL-OTS.